### PR TITLE
SDQ-4260: Adjust sensor regex to avoid duplicates

### DIFF
--- a/ZenPacks/community/CiscoPluggableOptics/modeler/plugins/community/snmp/CiscoPluggableOpticsMap.py
+++ b/ZenPacks/community/CiscoPluggableOptics/modeler/plugins/community/snmp/CiscoPluggableOpticsMap.py
@@ -112,7 +112,7 @@ Run SNMP queries, process returned values, find Cisco PluggableOptics sensors
                 m = re.search(r"slot\s+([\d\/]+)\s+transceiver.*\s+(\d+)\s+.*(temperature|current|voltage|power)", physDescr, re.IGNORECASE)
                 if m:
                     physSlot = m.group(1) + '/' + m.group(2)
-                if re.search(ifDescr + _sensor_regex, physDescr, re.IGNORECASE) or intfSlot == physSlot:
+                if re.search(r'^' + ifDescr + _sensor_regex, physDescr, re.IGNORECASE) or intfSlot == physSlot:
                     # give a friendlier name if the interface name did not match
                     if intfSlot == physSlot:
                         physDescr = re.sub(r'.*slot\s+([\d\/]+)\s+transceiver.*\s+(\d+)',ifDescr,physDescr)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.community.CiscoPluggableOptics"
-VERSION = "1.1.0"
-AUTHOR = "Russell Dwarshuis"
+VERSION = "1.1.1"
+AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2+"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.community']
 PACKAGES = ['ZenPacks', 'ZenPacks.community', 'ZenPacks.community.CiscoPluggableOptics']


### PR DESCRIPTION
# Summary
The modeler produces duplicate entries and will links sensors to the incorrect interface when names like "GigabitEthernet0/1 Module Temperature" and "TenGigabitEthernet0/1 Module Temperature" are present.
# Solution
Anchor the sensor name regex at the start of the string.
# Testing
Validated internally by Merit staff.